### PR TITLE
Fix missing `}` in 60b5dda / #55

### DIFF
--- a/tests/diff/to_nifti.py
+++ b/tests/diff/to_nifti.py
@@ -109,7 +109,7 @@ def diff_directories(baseline, test):
                     pixel_data = [numpy.asanyarray(x.dataobj) for x in images]
                     if not numpy.allclose(*pixel_data):
                         different = True
-                        print(f"Pixel data differences in {relative_filename")
+                        print(f"Pixel data differences in {relative_filename}")
                 else:
                     try:
                         subprocess.check_output(


### PR DESCRIPTION
Fix missing `}` in 60b5dda / #55.

You would think tests would catch it, but since the error is inside the error branch of a test, no luck.